### PR TITLE
Implement custom naming of product object

### DIFF
--- a/components/ViewContent.js
+++ b/components/ViewContent.js
@@ -1,9 +1,9 @@
 import prepareProductObject from '../util/prepareProductObject';
 import { isServer } from '@vue-storefront/core/helpers';
 
-export default {
+export default (productFieldToWatch) => ({
   watch: {
-    product: {
+    [productFieldToWatch]: {
       deep: true,
       immediate: true,
       handler (product, oldProduct) {
@@ -21,8 +21,8 @@ export default {
     }
   },
   methods: {
-    fbViewContent (product = this.product) {
+    fbViewContent (product = this[productFieldToWatch]) {
       window.fbq('track', 'ViewContent', prepareProductObject(product));
     }
   }
-};
+});


### PR DESCRIPTION
Someone may want to use for example `getCurrentProduct` object naming instead of `product`.